### PR TITLE
Fix unknown type in catch

### DIFF
--- a/front-end-resources/react-meeting/src/containers/BreakoutControls/BreakoutModal.tsx
+++ b/front-end-resources/react-meeting/src/containers/BreakoutControls/BreakoutModal.tsx
@@ -49,7 +49,12 @@ const BreakOutForm: React.FC = () => {
         await createMeeting(meetingId, `breakout-${meetingId}-${roomIndex}`, region)
       }
       catch (error) {
-        updateErrorMessage(error.message);
+        if (error instanceof Error) {
+          updateErrorMessage(error.message);
+        }
+        else {
+          throw error;
+        }
       }
     }
 

--- a/front-end-resources/react-meeting/src/containers/MeetingForm/RegionSelection.tsx
+++ b/front-end-resources/react-meeting/src/containers/MeetingForm/RegionSelection.tsx
@@ -42,7 +42,12 @@ const RegionSelection: React.FC<Props> = ({ setRegion, region }) => {
           setRegion((region: string) => region || nearestRegion);
         }
       } catch (e) {
-        console.error('Could not fetch nearest region: ', e.message);
+        if (e instanceof Error) {
+          console.error('Could not fetch nearest region: ', e.message);
+        }
+        else { 
+          throw e;
+        }
       }
     }
 

--- a/front-end-resources/react-meeting/src/containers/MeetingForm/index.tsx
+++ b/front-end-resources/react-meeting/src/containers/MeetingForm/index.tsx
@@ -79,7 +79,9 @@ const MeetingForm: React.FC = () => {
 
       history.push(routes.DEVICE);
     } catch (error) {
-      updateErrorMessage(error.message);
+      if (error instanceof Error) {
+        updateErrorMessage(error.message);
+      }
     }
   };
 

--- a/front-end-resources/react-meeting/src/containers/MeetingJoinDetails.tsx
+++ b/front-end-resources/react-meeting/src/containers/MeetingJoinDetails.tsx
@@ -33,7 +33,12 @@ const MeetingJoinDetails = () => {
       history.push(`${routes.MEETING}/${meetingId}`);
     } catch (error) {
       setIsLoading(false);
-      setError(error.message);
+      if (error instanceof Error) {
+        setError(error.message);
+      }
+      else {
+        throw error;
+      }
     }
   };
 

--- a/front-end-resources/react-meeting/src/containers/SIPMeeting/index.tsx
+++ b/front-end-resources/react-meeting/src/containers/SIPMeeting/index.tsx
@@ -34,7 +34,12 @@ const SIPMeeting: React.FC = () => {
         updateErrorMessage('Could not generate SIPURI');
       }
     } catch (error) {
-      updateErrorMessage(error.message);
+      if (error instanceof Error) {
+        updateErrorMessage(error.message);
+      }
+      else {
+        throw error;
+      }
     }
   };
 

--- a/front-end-resources/react-meeting/src/providers/SIPMeetingProvider/SIPMeetingManager.ts
+++ b/front-end-resources/react-meeting/src/providers/SIPMeetingProvider/SIPMeetingManager.ts
@@ -26,7 +26,11 @@ export class SIPMeetingManager {
       const joinToken = this.meetingData.JoinInfo.Attendee.JoinToken;
       return `sip:${AMAZON_CHIME_VOICE_CONNECTOR_PHONE_NUMDER}@${voiceConnectorId};transport=tls;X-joinToken=${joinToken}`;
     } catch (error) {
-      throw new Error(error);
+      if (error instanceof String) {
+        throw new Error(String(error));
+      } else {
+        throw error;
+      }
     }
   };
 }


### PR DESCRIPTION
*Issue #, if available:*
`Type 'unknown' is not assignable to type 'string'.  TS2345` occured when execute `./deploy.sh`

*Description of changes:*

Fixes are check instance type of error and re-throw if not type of Error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
